### PR TITLE
Update dev dependencies and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,14 +12,15 @@ jobs:
 
     strategy:
       matrix:
-        php: [ '8.0', '8.1' ]
+        php: [ '8.4', '8.5' ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup PHP ${{ matrix.php }}
-      uses: nanasess/setup-php@master
+      uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
+        extensions: mbstring, json
     - name: Install Dependencies
       run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
     - name: Execute tests via PHPUnit

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 vendor
 composer.lock
 .phpunit.result.cache
+.phpunit.cache
 .idea
 .DS_Store

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "psr/log": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.3.3",
-        "monolog/monolog": "^2.2"
+        "phpunit/phpunit": "^12.0",
+        "monolog/monolog": "^3.0"
     },
     "suggest": {
         "monolog/monolog": "An excellent logging solution, integrates seamlessly"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,17 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true"
->
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache">
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>


### PR DESCRIPTION
PHP 8.2 no longer allows us to use dynamic properties. Thus, we have to create them manually.